### PR TITLE
encodestring was removed in Python 3.9. Remove unused encodestring import

### DIFF
--- a/src/zope/app/i18n/browser/synchronize.py
+++ b/src/zope/app/i18n/browser/synchronize.py
@@ -37,7 +37,6 @@ except ImportError:
     from urllib.parse import urlparse
     from urllib.parse import urlunparse
 
-from base64 import encodestring
 
 import zope.i18nmessageid
 


### PR DESCRIPTION
Fixes #10 